### PR TITLE
Implement block caching

### DIFF
--- a/neuron/neuron/checkpoint.py
+++ b/neuron/neuron/checkpoint.py
@@ -2,7 +2,7 @@ import traceback
 from dataclasses import dataclass
 from os import urandom
 from time import perf_counter
-from typing import cast, Any
+from typing import cast, Any, Optional
 
 import bittensor as bt
 import torch
@@ -87,9 +87,10 @@ def get_submission(
     subtensor: bt.subtensor,
     metagraph: bt.metagraph,
     hotkey: str,
+    block: Optional[int] = None
 ) -> tuple[CheckpointSubmission, int] | None:
     try:
-        metadata = cast(dict[str, Any], get_metadata(subtensor, metagraph.netuid, hotkey))
+        metadata = cast(dict[str, Any], get_metadata(subtensor, metagraph.netuid, hotkey, block))
 
         if not metadata:
             return None

--- a/neuron/neuron/checkpoint.py
+++ b/neuron/neuron/checkpoint.py
@@ -2,7 +2,7 @@ import traceback
 from dataclasses import dataclass
 from os import urandom
 from time import perf_counter
-from typing import cast, Any, Optional
+from typing import cast, Any
 
 import bittensor as bt
 import torch
@@ -87,7 +87,7 @@ def get_submission(
     subtensor: bt.subtensor,
     metagraph: bt.metagraph,
     hotkey: str,
-    block: Optional[int] = None
+    block: int | None = None
 ) -> tuple[CheckpointSubmission, int] | None:
     try:
         metadata = cast(dict[str, Any], get_metadata(subtensor, metagraph.netuid, hotkey, block))

--- a/validator/validator/validator.py
+++ b/validator/validator/validator.py
@@ -32,7 +32,7 @@ from metrics import Metrics
 from wandb_args import add_wandb_args
 
 WEIGHTS_VERSION = 11
-VALIDATOR_VERSION = "1.0.0"
+VALIDATOR_VERSION = "1.0.1"
 
 WINNER_PERCENTAGE = 0.8
 IMPROVEMENT_BENCHMARK_PERCENTAGE = 1.05

--- a/validator/validator/validator.py
+++ b/validator/validator/validator.py
@@ -109,7 +109,7 @@ class Validator:
     wandb_run: Run | None
 
     current_block: int
-    last_block_fetch: datetime = None
+    last_block_fetch: datetime | None = None
 
     def __init__(self):
         self.config = get_config(Validator.add_extra_args)


### PR DESCRIPTION
Prevent repeated `get_current_block()` calls by caching the block, only updating it after 12 or more seconds and then passing the cached value to extrinsics.