### PR TITLE
Add size, vram, and watts metrics

### DIFF
--- a/neuron/neuron/checkpoint.py
+++ b/neuron/neuron/checkpoint.py
@@ -158,7 +158,6 @@ def generate(contest: Contest, pipeline: DiffusionPipeline, prompt: str, seed: i
 
 
 def compare_checkpoints(contest: Contest, repository: str) -> CheckpointBenchmark:
-    contest.start()
     failed = False
 
     baseline_pipeline = contest.load_baseline()
@@ -263,7 +262,6 @@ def compare_checkpoints(contest: Contest, repository: str) -> CheckpointBenchmar
             f"and watts usage of {watts_used}"
         )
 
-    contest.stop()
     return CheckpointBenchmark(
         baseline_average,
         average_time,

--- a/neuron/neuron/contest.py
+++ b/neuron/neuron/contest.py
@@ -3,10 +3,10 @@ from abc import ABC, abstractmethod
 from enum import Enum
 from pathlib import Path
 
+import pynvml
 import torch
 from diffusers import StableDiffusionXLPipeline
 from huggingface_hub import constants
-import pynvml
 
 from .coreml_pipeline import CoreMLStableDiffusionXLPipeline
 

--- a/neuron/neuron/vram_monitor.py
+++ b/neuron/neuron/vram_monitor.py
@@ -1,0 +1,42 @@
+import threading
+import time
+
+import pynvml
+import torch
+
+from contest import Contest
+
+POLL_RATE_SECONDS = 0.1
+
+
+class VRamMonitor:
+    _thread: threading.Thread
+    _device: torch.device
+    _contest: Contest
+    _vram_usage: set[int] = set()
+    _stop_flag: threading.Event
+    _lock: threading.Lock
+
+    def __init__(self, contest: Contest, device: torch.device):
+        self._contest = contest
+        self._device = device
+        self._stop_flag = threading.Event()
+        self._lock = threading.Lock()
+
+        self._thread = threading.Thread(target=self.monitor)
+        self._thread.start()
+
+    def monitor(self):
+        pynvml.nvmlInit()
+        while not self._stop_flag.is_set():
+            vram = self._contest.get_vram_used(self._device)
+            with self._lock:
+                self._vram_usage.add(vram)
+            time.sleep(POLL_RATE_SECONDS)
+        pynvml.nvmlShutdown()
+
+    def complete(self) -> float:
+        self._stop_flag.set()
+        self._thread.join()
+        with self._lock:
+            return sum(self._vram_usage) / len(self._vram_usage)

--- a/neuron/neuron/vram_monitor.py
+++ b/neuron/neuron/vram_monitor.py
@@ -1,7 +1,6 @@
 import threading
 import time
 
-import pynvml
 import torch
 
 from contest import Contest
@@ -27,13 +26,11 @@ class VRamMonitor:
         self._thread.start()
 
     def monitor(self):
-        pynvml.nvmlInit()
         while not self._stop_flag.is_set():
             vram = self._contest.get_vram_used(self._device)
             with self._lock:
                 self._vram_usage.add(vram)
             time.sleep(POLL_RATE_SECONDS)
-        pynvml.nvmlShutdown()
 
     def complete(self) -> float:
         self._stop_flag.set()

--- a/neuron/pyproject.toml
+++ b/neuron/pyproject.toml
@@ -42,6 +42,7 @@ transformers = "4.41.2"
 accelerate = "0.31.0"
 omegaconf = "2.3.0"
 python_coreml_stable_diffusion = { git = "https://github.com/apple/ml-stable-diffusion", tag = "1.1.1" }
+pynvml = "^11.5.3"
 
 [tool.poetry.dev-dependencies]
 pytype = "2024.4.11"

--- a/validator/validator/metrics.py
+++ b/validator/validator/metrics.py
@@ -10,7 +10,7 @@ class Metrics:
     model_averages: list[float]
     similarity_averages: list[float]
     sizes: list[int]
-    vram_used: list[int]
+    vram_used: list[float]
     watts_used: list[float]
 
     def __init__(self, metagraph: bt.metagraph):
@@ -22,7 +22,7 @@ class Metrics:
         self.model_averages = [0.0] * self.metagraph.n.item()
         self.similarity_averages = [0.0] * self.metagraph.n.item()
         self.sizes = [0] * self.metagraph.n.item()
-        self.vram_used = [0] * self.metagraph.n.item()
+        self.vram_used = [0.0] * self.metagraph.n.item()
         self.watts_used = [0.0] * self.metagraph.n.item()
 
     def reset(self, uid: int):
@@ -30,7 +30,7 @@ class Metrics:
         self.model_averages[uid] = 0.0
         self.similarity_averages[uid] = 0.0
         self.sizes[uid] = 0
-        self.vram_used[uid] = 0
+        self.vram_used[uid] = 0.0
         self.watts_used[uid] = 0.0
 
     def update(self, uid: int, benchmark: CheckpointBenchmark):

--- a/validator/validator/metrics.py
+++ b/validator/validator/metrics.py
@@ -1,44 +1,59 @@
 import bittensor as bt
 
-from neuron import CURRENT_CONTEST
+from neuron import CheckpointBenchmark
 
 
 class Metrics:
     metagraph: bt.metagraph
 
+    baseline_averages: list[float]
     model_averages: list[float]
     similarity_averages: list[float]
+    sizes: list[int]
+    vram_used: list[int]
 
     def __init__(self, metagraph: bt.metagraph):
         self.metagraph = metagraph
         self.clear()
 
     def clear(self):
+        self.baseline_averages = [0.0] * self.metagraph.n.item()
         self.model_averages = [0.0] * self.metagraph.n.item()
         self.similarity_averages = [0.0] * self.metagraph.n.item()
+        self.sizes = [0] * self.metagraph.n.item()
+        self.vram_used = [0.0] * self.metagraph.n.item()
 
     def reset(self, uid: int):
+        self.baseline_averages[uid] = 0.0
         self.model_averages[uid] = 0.0
         self.similarity_averages[uid] = 0.0
+        self.sizes[uid] = 0
+        self.vram_used[uid] = 0
 
-    def update(self, uid: int, generation_time: float, similarity: float):
-        self.model_averages[uid] = generation_time
-        self.similarity_averages[uid] = similarity
+    def update(self, uid: int, benchmark: CheckpointBenchmark):
+        self.baseline_averages[uid] = benchmark.baseline_average
+        self.model_averages[uid] = benchmark.average_time
+        self.similarity_averages[uid] = benchmark.average_similarity
+        self.sizes[uid] = benchmark.size
+        self.vram_used[uid] = benchmark.vram_used
 
     def resize(self):
-        def resize_data(data: list[float]) -> list[float]:
+        def resize_data(data: list) -> list:
             new_data = [0.0] * self.metagraph.n.item()
             length = len(self.metagraph.hotkeys)
             new_data[:length] = data[:length]
             return new_data
 
+        self.baseline_averages = resize_data(self.baseline_averages)
         self.model_averages = resize_data(self.model_averages)
         self.similarity_averages = resize_data(self.similarity_averages)
+        self.sizes = resize_data(self.sizes)
+        self.vram_used = resize_data(self.vram_used)
 
     def calculate_score(self, uid: int) -> float:
         return max(
             0.0,
-            CURRENT_CONTEST.baseline_average - self.model_averages[uid]
+            self.baseline_averages[uid] - self.model_averages[uid]
         ) * self.similarity_averages[uid]
 
     def set_metagraph(self, metagraph: bt.metagraph):
@@ -50,4 +65,5 @@ class Metrics:
         return state
 
     def __setstate__(self, state):
+        self.clear()
         self.__dict__.update(state)

--- a/validator/validator/metrics.py
+++ b/validator/validator/metrics.py
@@ -11,6 +11,7 @@ class Metrics:
     similarity_averages: list[float]
     sizes: list[int]
     vram_used: list[int]
+    watts_used: list[float]
 
     def __init__(self, metagraph: bt.metagraph):
         self.metagraph = metagraph
@@ -21,7 +22,8 @@ class Metrics:
         self.model_averages = [0.0] * self.metagraph.n.item()
         self.similarity_averages = [0.0] * self.metagraph.n.item()
         self.sizes = [0] * self.metagraph.n.item()
-        self.vram_used = [0.0] * self.metagraph.n.item()
+        self.vram_used = [0] * self.metagraph.n.item()
+        self.watts_used = [0.0] * self.metagraph.n.item()
 
     def reset(self, uid: int):
         self.baseline_averages[uid] = 0.0
@@ -29,6 +31,7 @@ class Metrics:
         self.similarity_averages[uid] = 0.0
         self.sizes[uid] = 0
         self.vram_used[uid] = 0
+        self.watts_used[uid] = 0.0
 
     def update(self, uid: int, benchmark: CheckpointBenchmark):
         self.baseline_averages[uid] = benchmark.baseline_average
@@ -36,6 +39,7 @@ class Metrics:
         self.similarity_averages[uid] = benchmark.average_similarity
         self.sizes[uid] = benchmark.size
         self.vram_used[uid] = benchmark.vram_used
+        self.watts_used[uid] = benchmark.watts_used
 
     def resize(self):
         def resize_data(data: list) -> list:
@@ -49,6 +53,7 @@ class Metrics:
         self.similarity_averages = resize_data(self.similarity_averages)
         self.sizes = resize_data(self.sizes)
         self.vram_used = resize_data(self.vram_used)
+        self.watts_used = resize_data(self.watts_used)
 
     def calculate_score(self, uid: int) -> float:
         return max(

--- a/validator/validator/validator.py
+++ b/validator/validator/validator.py
@@ -357,6 +357,7 @@ class Validator:
                         "similarity": self.metrics.similarity_averages[uid],
                         "size": self.metrics.sizes[uid],
                         "vram_used": self.metrics.vram_used[uid],
+                        "watts_used": self.metrics.watts_used[uid],
                         "hotkey": self.hotkeys[uid],
                         "multiday_winner": bucket.previous_day_winners,
                     }

--- a/validator/validator/validator.py
+++ b/validator/validator/validator.py
@@ -355,6 +355,8 @@ class Validator:
                         "model": cast(CheckpointSubmission, self.contest_state.miner_info[uid]).repository,
                         "generation_time": self.metrics.model_averages[uid],
                         "similarity": self.metrics.similarity_averages[uid],
+                        "size": self.metrics.sizes[uid],
+                        "vram_used": self.metrics.vram_used[uid],
                         "hotkey": self.hotkeys[uid],
                         "multiday_winner": bucket.previous_day_winners,
                     }
@@ -460,7 +462,7 @@ class Validator:
             if comparison.failed:
                 self.metrics.reset(uid)
             else:
-                self.metrics.update(uid, comparison.average_time, comparison.average_similarity)
+                self.metrics.update(uid, comparison)
         except Exception as e:
             self.metrics.reset(uid)
             bt.logging.info(f"Failed to query miner {uid}, {e}")


### PR DESCRIPTION
### Changes
- calculates VRAM used in bytes before and after image gen for baseline and model
- calculates the baseline and model size in bytes
- calculates the baseline generation time and uses that in the score calculation rather than a constant
- calculates watts used for baseline and model

### Notes
- did not implement apple silicon baseline size yet. not sure where the baseline model is saved
- did not implement watts for apple. did not look how to obtain that info yet