### PR TITLE
Baseline metrics

### DIFF
--- a/neuron/neuron/checkpoint.py
+++ b/neuron/neuron/checkpoint.py
@@ -218,10 +218,10 @@ def compare_checkpoints(contest: Contest, repository: str) -> CheckpointBenchmar
 
             bt.logging.info(
                 f"Sample {i} generated "
-                f"with generation time of {generation.generation_time} "
-                f"and similarity {similarity}"
-                f"and VRAM usage of {generation.vram_used}"
-                f"and watts usage of {generation.watts_used}"
+                f"with generation time of {generation.generation_time}, "
+                f"and similarity {similarity}, "
+                f"and VRAM usage of {generation.vram_used}, "
+                f"and watts usage of {generation.watts_used}."
             )
 
             if generated:
@@ -257,10 +257,10 @@ def compare_checkpoints(contest: Contest, repository: str) -> CheckpointBenchmar
         bt.logging.info(
             f"Tested {i + 1} samples, "
             f"average similarity of {average_similarity}, "
-            f"and speed of {average_time}"
-            f"and model size of {size}"
-            f"and VRAM usage of {vram_used}"
-            f"and watts usage of {watts_used}"
+            f"and speed of {average_time}, "
+            f"and model size of {size}, "
+            f"and VRAM usage of {vram_used}, "
+            f"and watts usage of {watts_used}."
         )
 
     return CheckpointBenchmark(

--- a/validator/validator/metrics.py
+++ b/validator/validator/metrics.py
@@ -74,7 +74,7 @@ class Metrics:
     def __setstate__(self, state):
 
         # For backwards compatibility
-        if not state["metrics"]:
+        if "metrics" not in state:
             state["metrics"] = [
                 MetricData(
                     baseline_average=state["baseline_averages"][i],

--- a/validator/validator/metrics.py
+++ b/validator/validator/metrics.py
@@ -1,65 +1,64 @@
+from dataclasses import dataclass
+
 import bittensor as bt
 
 from neuron import CheckpointBenchmark, CURRENT_CONTEST
 
 
+@dataclass
+class MetricData:
+    baseline_average: float
+    model_average: float
+    similarity_average: float
+    size: int
+    vram_used: float
+    watts_used: float
+
+    def __repr__(self):
+        return f"Metric(baseline_average={self.baseline_average}, model_average={self.model_average}, similarity_average={self.similarity_average}, size={self.size}, vram_used={self.vram_used}, watts_used={self.watts_used})"
+
+
+def new_metric_data() -> MetricData:
+    return MetricData(0.0, 0.0, 0.0, 0, 0.0, 0.0)
+
+
 class Metrics:
     metagraph: bt.metagraph
 
-    baseline_averages: list[float]
-    model_averages: list[float]
-    similarity_averages: list[float]
-    sizes: list[int]
-    vram_used: list[float]
-    watts_used: list[float]
+    metrics: list[MetricData]
 
     def __init__(self, metagraph: bt.metagraph):
         self.metagraph = metagraph
         self.clear()
 
     def clear(self):
-        self.baseline_averages = [0.0] * self.metagraph.n.item()
-        self.model_averages = [0.0] * self.metagraph.n.item()
-        self.similarity_averages = [0.0] * self.metagraph.n.item()
-        self.sizes = [0] * self.metagraph.n.item()
-        self.vram_used = [0.0] * self.metagraph.n.item()
-        self.watts_used = [0.0] * self.metagraph.n.item()
+        self.metrics = [new_metric_data()] * self.metagraph.n.item()
 
     def reset(self, uid: int):
-        self.baseline_averages[uid] = 0.0
-        self.model_averages[uid] = 0.0
-        self.similarity_averages[uid] = 0.0
-        self.sizes[uid] = 0
-        self.vram_used[uid] = 0.0
-        self.watts_used[uid] = 0.0
+        self.metrics[uid] = new_metric_data()
 
     def update(self, uid: int, benchmark: CheckpointBenchmark):
-        self.baseline_averages[uid] = benchmark.baseline_average
-        self.model_averages[uid] = benchmark.average_time
-        self.similarity_averages[uid] = benchmark.average_similarity
-        self.sizes[uid] = benchmark.size
-        self.vram_used[uid] = benchmark.vram_used
-        self.watts_used[uid] = benchmark.watts_used
+        self.metrics[uid] = MetricData(
+            baseline_average=benchmark.baseline_average,
+            model_average=benchmark.average_time,
+            similarity_average=benchmark.average_similarity,
+            size=benchmark.size,
+            vram_used=benchmark.vram_used,
+            watts_used=benchmark.watts_used
+        )
 
     def resize(self):
-        def resize_data(data: list) -> list:
-            new_data = [0.0] * self.metagraph.n.item()
-            length = len(self.metagraph.hotkeys)
-            new_data[:length] = data[:length]
-            return new_data
-
-        self.baseline_averages = resize_data(self.baseline_averages)
-        self.model_averages = resize_data(self.model_averages)
-        self.similarity_averages = resize_data(self.similarity_averages)
-        self.sizes = resize_data(self.sizes)
-        self.vram_used = resize_data(self.vram_used)
-        self.watts_used = resize_data(self.watts_used)
+        new_data = [new_metric_data()] * self.metagraph.n.item()
+        length = len(self.metagraph.hotkeys)
+        new_data[:length] = self.metrics[:length]
+        self.metrics = new_data
 
     def calculate_score(self, uid: int) -> float:
+        metric = self.metrics[uid]
         return max(
             0.0,
-            (self.baseline_averages[uid] or CURRENT_CONTEST.baseline_average) - self.model_averages[uid]
-        ) * self.similarity_averages[uid]
+            (metric.baseline_average or CURRENT_CONTEST.baseline_average) - metric.model_average
+        ) * metric.similarity_average
 
     def set_metagraph(self, metagraph: bt.metagraph):
         self.metagraph = metagraph
@@ -72,16 +71,19 @@ class Metrics:
     def __setstate__(self, state):
 
         # For backwards compatibility
-        if "baseline_averages" not in state:
-            state["baseline_averages"] = [0.0] * len(state["model_averages"])
-        if "sizes" not in state:
-            state["sizes"] = [0] * len(state["model_averages"])
-        if "vram_used" not in state:
-            state["vram_used"] = [0.0] * len(state["model_averages"])
-        if "watts_used" not in state:
-            state["watts_used"] = [0.0] * len(state["model_averages"])
+        if not state["metrics"]:
+            state["metrics"] = [
+                MetricData(
+                    baseline_average=state["baseline_averages"][i],
+                    model_average=state["model_averages"][i],
+                    similarity_average=state["similarity_averages"][i],
+                    size=state["sizes"][i],
+                    vram_used=state["vram_used"][i],
+                    watts_used=state["watts_used"][i]
+                )
+                for i in range(len(state["model_averages"]))]
 
         self.__dict__.update(state)
 
     def __repr__(self):
-        return f"Metrics(baseline_averages={self.baseline_averages}, model_averages={self.model_averages}, similarity_averages={self.similarity_averages}, sizes={self.sizes}, vram_used={self.vram_used}, watts_used={self.watts_used})"
+        return f"Metrics(metrics={self.metrics})"

--- a/validator/validator/metrics.py
+++ b/validator/validator/metrics.py
@@ -1,6 +1,6 @@
 import bittensor as bt
 
-from neuron import CheckpointBenchmark
+from neuron import CheckpointBenchmark, CURRENT_CONTEST
 
 
 class Metrics:
@@ -58,7 +58,7 @@ class Metrics:
     def calculate_score(self, uid: int) -> float:
         return max(
             0.0,
-            self.baseline_averages[uid] - self.model_averages[uid]
+            (self.baseline_averages[uid] or CURRENT_CONTEST.baseline_average) - self.model_averages[uid]
         ) * self.similarity_averages[uid]
 
     def set_metagraph(self, metagraph: bt.metagraph):

--- a/validator/validator/validator.py
+++ b/validator/validator/validator.py
@@ -359,15 +359,18 @@ class Validator:
                 bucket_rank = highest_bucket - index
 
                 for uid, score in bucket.scores:
+                    metric = self.metrics.metrics[uid]
                     log_data[str(uid)] = {
                         "rank": bucket_rank,
                         "model": cast(CheckpointSubmission, self.contest_state.miner_info[uid]).repository,
-                        "baseline": self.metrics.baseline_averages[uid],
-                        "generation_time": self.metrics.model_averages[uid],
-                        "similarity": self.metrics.similarity_averages[uid],
-                        "size": self.metrics.sizes[uid],
-                        "vram_used": self.metrics.vram_used[uid],
-                        "watts_used": self.metrics.watts_used[uid],
+                        "baseline_generation_time": metric.baseline_average,
+                        "generation_time": metric.model_average,
+                        "similarity": metric.similarity_average,
+                        "size": metric.size,
+                        "baseline_vram_used": metric.vram_used,
+                        "vram_used": metric.vram_used,
+                        "baseline_watts_used": metric.watts_used,
+                        "watts_used": metric.watts_used,
                         "hotkey": self.hotkeys[uid],
                         "multiday_winner": bucket.previous_day_winners,
                     }
@@ -490,7 +493,7 @@ class Validator:
         sorted_contestants = [
             (uid, score)
             for uid, score in sorted(enumerate(scores), key=lambda score: score[1])
-            if score > 0.0
+            if score is not None
         ]
 
         buckets: list[WinnerList] = [[]]

--- a/validator/validator/validator.py
+++ b/validator/validator/validator.py
@@ -486,15 +486,7 @@ class Validator:
         self.contest_state.miner_score_versions[uid] = WEIGHTS_VERSION
 
     def get_score_buckets(self) -> list[WinnerList]:
-        uid: Uid
-
-        scores = [self.metrics.calculate_score(uid) for uid in range(self.metagraph.n.item())]
-
-        sorted_contestants = [
-            (uid, score)
-            for uid, score in sorted(enumerate(scores), key=lambda score: score[1])
-            if score is not None
-        ]
+        sorted_contestants = self.metrics.get_sorted_contestants()
 
         buckets: list[WinnerList] = [[]]
 

--- a/validator/validator/validator.py
+++ b/validator/validator/validator.py
@@ -362,6 +362,7 @@ class Validator:
                     log_data[str(uid)] = {
                         "rank": bucket_rank,
                         "model": cast(CheckpointSubmission, self.contest_state.miner_info[uid]).repository,
+                        "baseline": self.metrics.baseline_averages[uid],
                         "generation_time": self.metrics.model_averages[uid],
                         "similarity": self.metrics.similarity_averages[uid],
                         "size": self.metrics.sizes[uid],


### PR DESCRIPTION
- send the baseline scores that are calculated per-validator so that the leaderboard and webhook are more accurate
- clean up metrics
- allow miners with a score of 0 to show on the leaderboard