### PR TITLE
Prevent bittensor import in API

### DIFF
--- a/miner/miner/submit.py
+++ b/miner/miner/submit.py
@@ -2,18 +2,19 @@ import re
 from argparse import ArgumentParser
 
 from git import GitCommandError, cmd
+import bittensor as bt
 
 from neuron import (
-    bt,
     CheckpointSubmission,
     get_config,
-    make_submission,
     find_contest,
     Contest,
     CURRENT_CONTEST,
     CONTESTS,
     ContestId,
 )
+
+from neuron.submissions import make_submission
 
 VALID_REPO_REGEX = r'^https:\/\/[a-zA-Z0-9.-]+\/[a-zA-Z0-9._-]+\/[a-zA-Z0-9._-]+$'
 VALID_REVISION_REGEX = r"^[a-f0-9]{7}$"

--- a/miner/miner/submit.py
+++ b/miner/miner/submit.py
@@ -2,9 +2,9 @@ import re
 from argparse import ArgumentParser
 
 from git import GitCommandError, cmd
-import bittensor as bt
 
 from neuron import (
+    bt,
     CheckpointSubmission,
     get_config,
     find_contest,

--- a/neuron/neuron/bt.py
+++ b/neuron/neuron/bt.py
@@ -1,4 +1,3 @@
 from bittensor import *
-from bittensor.extrinsics.serving import *
 
 logging.enable_third_party_loggers()

--- a/neuron/neuron/checkpoint.py
+++ b/neuron/neuron/checkpoint.py
@@ -1,7 +1,5 @@
-from typing import cast, Any, TypeAlias
+from typing import TypeAlias
 
-import neuron.bt as bt
-from bittensor.extrinsics.serving import get_metadata, publish_metadata
 from pydantic import BaseModel
 
 from .contest import ContestId, CURRENT_CONTEST
@@ -44,66 +42,3 @@ def should_update(old_info: CheckpointSubmission | None, new_info: CheckpointSub
         return True
 
     return old_info.repository != new_info.repository or old_info.revision != new_info.revision
-
-
-def make_submission(
-    subtensor: bt.subtensor,
-    metagraph: bt.metagraph,
-    wallet: bt.wallet,
-    submission: CheckpointSubmission,
-):
-    encoder = Encoder()
-
-    encoder.write_uint16(SPEC_VERSION)
-
-    submission.encode(encoder)
-
-    data = encoder.finish()
-
-    publish_metadata(
-        subtensor,
-        wallet,
-        metagraph.netuid,
-        f"Raw{len(data)}",
-        data,
-        wait_for_finalization=False,
-    )
-
-
-def get_submission(
-    subtensor: bt.subtensor,
-    metagraph: bt.metagraph,
-    hotkey: Key,
-    block: int | None = None
-) -> tuple[CheckpointSubmission, int] | None:
-    try:
-        metadata = cast(dict[str, Any], get_metadata(subtensor, metagraph.netuid, hotkey, block))
-
-        if not metadata:
-            return None
-
-        block: int = metadata["block"]
-        commitment: dict[str, str] = metadata["info"]["fields"][0]
-        hex_data = commitment.values().__iter__().__next__()
-        data = bytes.fromhex(hex_data[2:])
-        decoder = Decoder(data)
-
-        spec_version = decoder.read_uint16()
-
-        if spec_version != SPEC_VERSION:
-            return None
-
-        info = CheckpointSubmission.decode(decoder)
-
-        if (
-            info.contest != CURRENT_CONTEST.id or
-            info.repository == CURRENT_CONTEST.baseline_repository or
-            info.revision == CURRENT_CONTEST.baseline_revision
-        ):
-            return None
-
-        return info, block
-    except Exception as e:
-        bt.logging.error(f"Failed to get submission from miner {hotkey}")
-        bt.logging.debug(f"Submission parsing error", exc_info=e)
-        return None

--- a/neuron/neuron/config.py
+++ b/neuron/neuron/config.py
@@ -3,7 +3,7 @@ from typing import Callable
 
 
 def get_config(add_args: Callable[[ArgumentParser], None] | None = None):
-    import bittensor as bt
+    import neuron.bt as bt
     argument_parser = ArgumentParser()
 
     argument_parser.add_argument(

--- a/neuron/neuron/config.py
+++ b/neuron/neuron/config.py
@@ -1,10 +1,9 @@
 from argparse import ArgumentParser
 from typing import Callable
 
-import neuron.bt as bt
-
 
 def get_config(add_args: Callable[[ArgumentParser], None] | None = None):
+    import bittensor as bt
     argument_parser = ArgumentParser()
 
     argument_parser.add_argument(

--- a/neuron/neuron/submissions.py
+++ b/neuron/neuron/submissions.py
@@ -1,0 +1,72 @@
+from typing import cast, Any
+
+import bittensor as bt
+from bittensor.extrinsics.serving import get_metadata, publish_metadata
+
+from .checkpoint import CheckpointSubmission, SPEC_VERSION, Key
+from .contest import CURRENT_CONTEST
+from .network_commitments import Encoder, Decoder
+
+
+def make_submission(
+    subtensor: bt.subtensor,
+    metagraph: bt.metagraph,
+    wallet: bt.wallet,
+    submission: CheckpointSubmission,
+):
+
+    encoder = Encoder()
+
+    encoder.write_uint16(SPEC_VERSION)
+
+    submission.encode(encoder)
+
+    data = encoder.finish()
+
+    publish_metadata(
+        subtensor,
+        wallet,
+        metagraph.netuid,
+        f"Raw{len(data)}",
+        data,
+        wait_for_finalization=False,
+    )
+
+
+def get_submission(
+    subtensor: bt.subtensor,
+    metagraph: bt.metagraph,
+    hotkey: Key,
+    block: int | None = None
+) -> tuple[CheckpointSubmission, int] | None:
+    try:
+        metadata = cast(dict[str, Any], get_metadata(subtensor, metagraph.netuid, hotkey, block))
+
+        if not metadata:
+            return None
+
+        block: int = metadata["block"]
+        commitment: dict[str, str] = metadata["info"]["fields"][0]
+        hex_data = commitment.values().__iter__().__next__()
+        data = bytes.fromhex(hex_data[2:])
+        decoder = Decoder(data)
+
+        spec_version = decoder.read_uint16()
+
+        if spec_version != SPEC_VERSION:
+            return None
+
+        info = CheckpointSubmission.decode(decoder)
+
+        if (
+            info.contest != CURRENT_CONTEST.id or
+            info.repository == CURRENT_CONTEST.baseline_repository or
+            info.revision == CURRENT_CONTEST.baseline_revision
+        ):
+            return None
+
+        return info, block
+    except Exception as e:
+        bt.logging.error(f"Failed to get submission from miner {hotkey}")
+        bt.logging.debug(f"Submission parsing error", exc_info=e)
+        return None

--- a/neuron/neuron/submissions.py
+++ b/neuron/neuron/submissions.py
@@ -1,6 +1,6 @@
 from typing import cast, Any
 
-import bittensor as bt
+import neuron.bt as bt
 from bittensor.extrinsics.serving import get_metadata, publish_metadata
 
 from .checkpoint import CheckpointSubmission, SPEC_VERSION, Key

--- a/validator/weight_setting/diagnostics.py
+++ b/validator/weight_setting/diagnostics.py
@@ -9,7 +9,7 @@ from os.path import expanduser, join, isfile
 from pathlib import Path
 
 from pickle import load
-import bittensor as bt
+import neuron.bt as bt
 
 from .validator import ContestState  # noqa (Needed for depickling)
 

--- a/validator/weight_setting/diagnostics.py
+++ b/validator/weight_setting/diagnostics.py
@@ -9,7 +9,7 @@ from os.path import expanduser, join, isfile
 from pathlib import Path
 
 from pickle import load
-from neuron import bt
+import bittensor as bt
 
 from .validator import ContestState  # noqa (Needed for depickling)
 

--- a/validator/weight_setting/validator.py
+++ b/validator/weight_setting/validator.py
@@ -24,13 +24,12 @@ from tqdm import tqdm
 from wandb.sdk.wandb_run import Run
 from websockets import ConnectionClosedError
 from websockets.sync.client import connect, ClientConnection
+import bittensor as bt
 
 from neuron import (
-    bt,
     CheckpointSubmission,
     get_config,
     ContestId,
-    get_submission,
     CURRENT_CONTEST,
     find_contest,
     ContestDeviceValidationError,
@@ -39,6 +38,8 @@ from neuron import (
     Uid,
     should_update,
 )
+
+from neuron.submissions import get_submission
 
 from base_validator import API_VERSION
 from base_validator.metrics import BenchmarkResults, BenchmarkState, CheckpointBenchmark

--- a/validator/weight_setting/validator.py
+++ b/validator/weight_setting/validator.py
@@ -24,9 +24,9 @@ from tqdm import tqdm
 from wandb.sdk.wandb_run import Run
 from websockets import ConnectionClosedError
 from websockets.sync.client import connect, ClientConnection
-import bittensor as bt
 
 from neuron import (
+    bt,
     CheckpointSubmission,
     get_config,
     ContestId,


### PR DESCRIPTION
Prevents bittensor from being imported indirectly in the API, causing logging issues like with uvicorn logging