### PR TITLE
Implement log streaming

### DIFF
--- a/validator/base_validator/__init__.py
+++ b/validator/base_validator/__init__.py
@@ -1,1 +1,1 @@
-API_VERSION = "2.3.5"
+API_VERSION = "2.3.6"

--- a/validator/submission_tester/api.py
+++ b/validator/submission_tester/api.py
@@ -96,7 +96,7 @@ async def stream_logs(websocket: WebSocket):
         while True:
             if not logs.empty():
                 message = logs.get()
-                await websocket.send_text(f"[API] - {message}")
+                await websocket.send_text(message)
             await asyncio.sleep(0.1)
     except Exception as e:
         logger.error(f"WebSocket error", exc_info=e)

--- a/validator/submission_tester/inference_sandbox.py
+++ b/validator/submission_tester/inference_sandbox.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import sys
 import time
 from multiprocessing.connection import Client
 from os.path import abspath
@@ -57,7 +58,7 @@ class InferenceSandbox(Generic[RequestT]):
                 encoding='utf-8',
             )
             print(start_process.stdout)
-            print(start_process.stderr)
+            print(start_process.stderr, file=sys.stderr)
             start_process.check_returncode()
 
         except CalledProcessError as e:
@@ -122,7 +123,7 @@ class InferenceSandbox(Generic[RequestT]):
         )
 
         print(process.stdout)
-        print(process.stderr)
+        print(process.stderr, file=sys.stderr)
         process.check_returncode()
 
     def __enter__(self):

--- a/validator/submission_tester/inference_sandbox.py
+++ b/validator/submission_tester/inference_sandbox.py
@@ -1,12 +1,11 @@
 import logging
 import os
-import sys
 import time
 from multiprocessing.connection import Client
 from os.path import abspath
 from pathlib import Path
 from subprocess import Popen, run, TimeoutExpired, CalledProcessError
-from typing import Generic, cast, IO
+from typing import Generic
 
 from neuron import RequestT
 
@@ -31,20 +30,6 @@ class InvalidSubmissionError(Exception):
     ...
 
 
-class OutputDelegate:
-    _name: str
-
-    def __init__(self, name: str):
-        self._name = name
-
-    def __getattr__(self, item):
-        return getattr(getattr(sys, self._name), item)
-
-
-def delegate(name: str):
-    return cast(IO[str], OutputDelegate(name))
-
-
 class InferenceSandbox(Generic[RequestT]):
     _repository: str
 
@@ -59,7 +44,7 @@ class InferenceSandbox(Generic[RequestT]):
         self._baseline = baseline
 
         try:
-            run(
+            start_process = run(
                 [
                     *sandbox_args(self._user),
                     SETUP_INFERENCE_SANDBOX_SCRIPT,
@@ -68,9 +53,13 @@ class InferenceSandbox(Generic[RequestT]):
                     revision,
                     str(baseline).lower(),
                 ],
-                stdout=delegate("stdout"),
-                stderr=delegate("stderr"),
-            ).check_returncode()
+                capture_output=True,
+                encoding='utf-8',
+            )
+            print(start_process.stdout)
+            print(start_process.stderr)
+            start_process.check_returncode()
+
         except CalledProcessError as e:
             if baseline:
                 self.clear_sandbox()
@@ -88,8 +77,6 @@ class InferenceSandbox(Generic[RequestT]):
                 abspath(self._sandbox_directory / ".venv" / "bin" / "start_inference")
             ],
             cwd=self._sandbox_directory,
-            stdout=sys.stdout,
-            stderr=sys.stderr,
         )
 
         logger.info(f"Inference process starting")
@@ -121,7 +108,7 @@ class InferenceSandbox(Generic[RequestT]):
             raise InvalidSubmissionError(f"'{self._repository}'s inference crashed, got exit code {self._process.returncode}")
 
     def clear_sandbox(self):
-        run(
+        process = run(
             [
                 *sandbox_args(self._user),
                 "find",
@@ -130,9 +117,13 @@ class InferenceSandbox(Generic[RequestT]):
                 "1",
                 "-delete",
             ],
-            stdout=sys.stdout,
-            stderr=sys.stderr,
-        ).check_returncode()
+            capture_output=True,
+            encoding='utf-8',
+        )
+
+        print(process.stdout)
+        print(process.stderr)
+        process.check_returncode()
 
     def __enter__(self):
         self._process.__enter__()

--- a/validator/submission_tester/setup_inference_sandbox.sh
+++ b/validator/submission_tester/setup_inference_sandbox.sh
@@ -18,14 +18,14 @@ else
   find "$SANDBOX_DIRECTORY" -mindepth 1 -delete
 
   git config --global advice.detachedHead false
-  git clone --shallow-submodules --no-checkout --progress "$REPOSITORY_URL" "$SANDBOX_DIRECTORY"
+  git clone --shallow-submodules --no-checkout "$REPOSITORY_URL" "$SANDBOX_DIRECTORY"
   if $($BASELINE); then
     touch "$READY_MARKER"
   fi
 fi
 
 git checkout "$REVISION"
-git submodule update --init --progress
+git submodule update --init
 
 if ! [ -f "$VENV" ]; then
   python3.10 -m venv "$VENV"

--- a/validator/weight_setting/diagnostics.py
+++ b/validator/weight_setting/diagnostics.py
@@ -11,7 +11,7 @@ from pathlib import Path
 from pickle import load
 import neuron.bt as bt
 
-from .validator import ContestState  # noqa (Needed for depickling)
+from weight_setting.validator import ContestState  # noqa (Needed for depickling)
 
 DIAGNOSTICS_DIR: Path = Path(".diagnostics")
 DIAGNOSTICS_FILE_PATH: Path = DIAGNOSTICS_DIR / "diagnostics.json"

--- a/validator/weight_setting/validator.py
+++ b/validator/weight_setting/validator.py
@@ -674,7 +674,7 @@ class Validator:
                 for line in self.websocket:
                     output = sys.stderr if line.startswith("err:") else sys.stdout
 
-                    print(f"[API] - {line[4:]}", file=output)
+                    print(f"[API] -{line[4:]}", file=output)
             except ConnectionClosedError:
                 self.websocket = self.connect_to_api()
 

--- a/validator/weight_setting/validator.py
+++ b/validator/weight_setting/validator.py
@@ -9,7 +9,6 @@ from datetime import date, datetime
 from operator import itemgetter
 from os import makedirs
 from os.path import isfile, expanduser, join
-from threading import Thread
 from typing import cast, TypeAlias
 from zoneinfo import ZoneInfo
 
@@ -133,7 +132,6 @@ class Validator:
     contest: Contest
 
     websocket: ClientConnection
-    log_thread: Thread
 
     def __init__(self):
         self.config = get_config(Validator.add_extra_args)

--- a/validator/weight_setting/validator.py
+++ b/validator/weight_setting/validator.py
@@ -674,7 +674,7 @@ class Validator:
                 for line in self.websocket:
                     output = sys.stderr if line.startswith("err:") else sys.stdout
 
-                    print(line[4:], file=output)
+                    print(f"[API] - {line[4:]}", file=output)
             except ConnectionClosedError:
                 self.websocket = self.connect_to_api()
 

--- a/validator/weight_setting/validator.py
+++ b/validator/weight_setting/validator.py
@@ -1,4 +1,3 @@
-import asyncio
 import json
 import random
 import sys
@@ -9,6 +8,7 @@ from datetime import date, datetime
 from operator import itemgetter
 from os import makedirs
 from os.path import isfile, expanduser, join
+from threading import Thread
 from typing import cast, TypeAlias
 from zoneinfo import ZoneInfo
 
@@ -174,7 +174,7 @@ class Validator:
         self.contest = find_contest(self.contest_state.id) if self.contest_state else CURRENT_CONTEST
 
         self.websocket = self.connect_to_api()
-        asyncio.run(self.api_logs())
+        Thread(target=self.api_logs).start()
 
     def new_wandb_run(self):
         """Creates a new wandb run to save information to."""
@@ -668,13 +668,13 @@ class Validator:
 
         return websocket
 
-    async def api_logs(self):
+    def api_logs(self):
         while True:
             try:
                 for line in self.websocket:
                     output = sys.stderr if line.startswith("err:") else sys.stdout
 
-                    print(line, file=output)
+                    print(line[4:], file=output)
             except ConnectionClosedError:
                 self.websocket = self.connect_to_api()
 


### PR DESCRIPTION
streams logs from the API to the Validator. will send everything from the API logger, along with output from `subprocess.run`

### Changes to Subprocess Logging
now logs everything after the process completes rather than streaming it directly to stdout live. this is to make it compatible with log streaming

no longer logs from `subprocess.Popen`. couldn't figure out a clean way to stream those logs live when inference is being ran. still logs each sample along with the final benchmarks, though.
