### PR TITLE
Implement dependency blacklist, block pyarmor

### DIFF
--- a/validator/base_validator/__init__.py
+++ b/validator/base_validator/__init__.py
@@ -1,1 +1,1 @@
-API_VERSION = "3.0.0"
+API_VERSION = "3.1.0"

--- a/validator/submission_tester/dependency_blacklist.txt
+++ b/validator/submission_tester/dependency_blacklist.txt
@@ -1,0 +1,1 @@
+pyarmor

--- a/validator/submission_tester/inference_sandbox.py
+++ b/validator/submission_tester/inference_sandbox.py
@@ -47,6 +47,7 @@ class InferenceSandbox(Generic[RequestT]):
         with open(DEPENDENCY_BLACKLIST, 'r') as f:
             blacklisted_dependencies = f.read().splitlines()
 
+        start_process = None
         try:
             start_process = run(
                 [
@@ -73,8 +74,9 @@ class InferenceSandbox(Generic[RequestT]):
                 else:
                     raise InvalidSubmissionError(f"Failed to setup sandbox: {e}")
         finally:
-            print(start_process.stdout)
-            print(start_process.stderr, file=sys.stderr)
+            if start_process:
+                print(start_process.stdout)
+                print(start_process.stderr, file=sys.stderr)
 
         self._file_size = sum(file.stat().st_size for file in self._sandbox_directory.rglob("*"))
 

--- a/validator/submission_tester/inference_sandbox.py
+++ b/validator/submission_tester/inference_sandbox.py
@@ -16,6 +16,9 @@ SANDBOX_DIRECTORY = Path("/sandbox")
 BASELINE_SANDBOX_DIRECTORY = Path("/baseline-sandbox")
 DEPENDENCY_BLACKLIST = abspath(Path(__file__).parent / "dependency_blacklist.txt")
 
+with open(DEPENDENCY_BLACKLIST, 'r') as blacklist_file:
+    BLACKLISTED_DEPENDENCIES = " ".join(blacklist_file.read().splitlines())
+
 logger = logging.getLogger(__name__)
 
 
@@ -44,9 +47,6 @@ class InferenceSandbox(Generic[RequestT]):
 
         self._baseline = baseline
 
-        with open(DEPENDENCY_BLACKLIST, 'r') as f:
-            blacklisted_dependencies = f.read().splitlines()
-
         start_process = None
         try:
             start_process = run(
@@ -57,7 +57,7 @@ class InferenceSandbox(Generic[RequestT]):
                     repository_info.url,
                     repository_info.revision,
                     str(baseline).lower(),
-                    " ".join(blacklisted_dependencies),
+                    BLACKLISTED_DEPENDENCIES,
                 ],
                 capture_output=True,
                 encoding='utf-8',

--- a/validator/submission_tester/inference_sandbox.py
+++ b/validator/submission_tester/inference_sandbox.py
@@ -14,7 +14,7 @@ SETUP_INFERENCE_SANDBOX_SCRIPT = abspath(Path(__file__).parent / "setup_inferenc
 
 SANDBOX_DIRECTORY = Path("/sandbox")
 BASELINE_SANDBOX_DIRECTORY = Path("/baseline-sandbox")
-DEPENDENCY_BLACKLIST = Path("submission_tester/dependency_blacklist.txt")
+DEPENDENCY_BLACKLIST = abspath(Path(__file__).parent / "dependency_blacklist.txt")
 
 logger = logging.getLogger(__name__)
 

--- a/validator/submission_tester/setup_inference_sandbox.sh
+++ b/validator/submission_tester/setup_inference_sandbox.sh
@@ -6,6 +6,7 @@ SANDBOX_DIRECTORY=$1
 REPOSITORY_URL=$2
 REVISION=$3
 BASELINE=$4
+BLACKLISTED_DEPENDENCIES=$5
 
 READY_MARKER="$SANDBOX_DIRECTORY/ready"
 VENV="$SANDBOX_DIRECTORY/.venv"
@@ -17,23 +18,51 @@ if $($BASELINE) && [ -f "$READY_MARKER" ]; then
 else
   find "$SANDBOX_DIRECTORY" -mindepth 1 -delete
 
-  git clone --shallow-submodules --no-checkout "$REPOSITORY_URL" "$SANDBOX_DIRECTORY"
+  GIT_LFS_SKIP_SMUDGE=1 git clone --depth 1 --shallow-submodules "$REPOSITORY_URL" "$SANDBOX_DIRECTORY"
   if $($BASELINE); then
     touch "$READY_MARKER"
   fi
 fi
 
+FULL_REVISION=$(git rev-parse "$REVISION")
+git fetch --depth 1 origin "$FULL_REVISION"
 git checkout "$REVISION"
-git submodule update --init
 
+check_blacklist() {
+  local file="$1"
+  if [ -f "$file" ]; then
+    while IFS= read -r line; do
+      for dependency in $BLACKLISTED_DEPENDENCIES; do
+        if [[ "$line" == *"$dependency"* ]]; then
+          echo "Found blacklisted dependency '$dependency' in file '$file'"
+          exit 2
+        fi
+      done
+    done < "$file"
+  fi
+}
+
+REQUIREMENTS="$SANDBOX_DIRECTORY/requirements.txt"
+PYPROJECT="$SANDBOX_DIRECTORY/pyproject.toml"
+PIPELINE="$SANDBOX_DIRECTORY/src/pipeline.py"
+
+check_blacklist "$REQUIREMENTS"
+check_blacklist "$PYPROJECT"
+check_blacklist "$PIPELINE"
+
+echo "Pulling LFS files..."
+git lfs pull
+git submodule update --init
+echo "Pulled LFS files."
+
+echo "Installing dependencies..."
 if ! [ -f "$VENV" ]; then
   python3.10 -m venv "$VENV"
 fi
-
-REQUIREMENTS="$SANDBOX_DIRECTORY/requirements.txt"
 
 if [ -f "$REQUIREMENTS" ]; then
   "$VENV/bin/pip" install -q -r "$REQUIREMENTS" -e "$SANDBOX_DIRECTORY"
 else
   "$VENV/bin/pip" install -q -e "$SANDBOX_DIRECTORY"
 fi
+echo "Installed dependencies."

--- a/validator/weight_setting/validator.py
+++ b/validator/weight_setting/validator.py
@@ -42,10 +42,10 @@ from neuron import (
 from neuron.submissions import get_submission
 from .wandb_args import add_wandb_args
 
-VALIDATOR_VERSION = "3.3.0"
-WEIGHTS_VERSION = 33
+VALIDATOR_VERSION = "3.4.0"
+WEIGHTS_VERSION = 34
 
-COLLECTED_SUBMISSIONS_VERSION = 1
+COLLECTED_SUBMISSIONS_VERSION = 2
 
 
 logger = get_logger(__name__)

--- a/validator/weight_setting/validator.py
+++ b/validator/weight_setting/validator.py
@@ -45,7 +45,7 @@ from .wandb_args import add_wandb_args
 VALIDATOR_VERSION = "3.4.0"
 WEIGHTS_VERSION = 34
 
-COLLECTED_SUBMISSIONS_VERSION = 2
+COLLECTED_SUBMISSIONS_VERSION = 1
 
 
 logger = get_logger(__name__)


### PR DESCRIPTION
Adds a blacklist file for blocking certain dependencies. currently only blocks pyarmor. Also split the LFS install into two, installing the initial repository first, then checking the blacklist, then pulling the LFS files, to avoid cloning the entire repository for an invalid submission.